### PR TITLE
PE-4948: lets put back buffering_size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_kinesis_firehose_delivery_stream" "this_kinesis" {
   name        = var.kinesis_delivery_stream_name
   destination = "extended_s3"
   extended_s3_configuration {
-
+    buffering_size      = 128
     role_arn            = aws_iam_role.this_shared_iam_role.arn
     bucket_arn          = var.warehouse_bucket_arn
     error_output_prefix = var.kinesis_s3_errors_prefix


### PR DESCRIPTION
I have added back buffering size default value, now we have new aws terraform provider in data-warehouse 

## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Testing considerations

<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Fix bug with logging` -->
- [ ] Commits are squashed in a logical and understandable history <!-- e.g. avoid 'fix' commits -->
- [ ] Thoroughly tested the changes in development and/or staging
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [!XYZ](https://github.com/scribd/REPO/pull/XYZ)
* [JIRXXX](https://scribdjira.atlassian.net/browse/JIRXXX)
* [Design Document](https://scribdjira.atlassian.net/wiki/spaces/SPACEID/pages/PAGEID)
* [Slack discussion](https://scribd.slack.com/archives/C0DSL144T/p1564610596278400)
