### PR TITLE
[PE-5232] Adding SNS topic envelope decode and subscription option

### DIFF
--- a/autotagging.tf
+++ b/autotagging.tf
@@ -15,6 +15,12 @@ resource "aws_lambda_function" "auto_tagging" {
   timeout                        = var.lambda_timeout
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
 
+  environment {
+    variables = {
+      UNWRAP_SNS_ENVELOPE     = var.sns_topic_arn == "" ? false : true
+    }
+  }
+
   tags = var.tags
 }
 
@@ -41,6 +47,14 @@ resource "aws_sqs_queue" "auto_tagging" {
   })
 
   tags = var.tags
+}
+
+resource "aws_sns_topic_subscription" "auto_tagging" {
+  count = var.sns_topic_arn == "" ? 0 : 1
+
+  topic_arn = var.sns_topic_arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.auto_tagging.arn
 }
 
 resource "aws_lambda_event_source_mapping" "auto_tagging" {

--- a/variables.tf
+++ b/variables.tf
@@ -291,3 +291,9 @@ variable "enable_auto_tagging" {
   description = "Whether to turn on Auto Tagging Lambda"
   default     = false
 }
+
+variable "sns_topic_arn" {
+  type        = string
+  description = "Optional arn to enable the SNS subscription and ENV var for Oxbo"
+  default     = ""
+}


### PR DESCRIPTION
## Description

This PR updates the Terraform module to support the new changes in Oxbo that allow for SNS enveloped message decoding.

Introduces a new option input variable `sns_topic_arn` that when populated, enables the new env var for Oxbo and auto tagging lambdas to decode the messages received as SNS messages

Also creates an SNS subscription resource that subscribes the SQS queues for the Lambda's to the provided SNS topic


## Testing considerations

<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Fix bug with logging` -->
- [ ] Commits are squashed in a logical and understandable history <!-- e.g. avoid 'fix' commits -->
- [ ] Thoroughly tested the changes in development and/or staging
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

* [PE-5232](https://scribdjira.atlassian.net/browse/PE-5232)

[PE-5232]: https://scribdjira.atlassian.net/browse/PE-5232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ