### PR TITLE
[TOOLS-7104] Update github actions due to node 16 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: hashicorp/setup-terraform@v1
         with:


### PR DESCRIPTION
Use sourcegraph batch change to update github actions due to node 16 deprecation.

[_Created by Sourcegraph batch change `kristianmills/sourcegraph-node-16-v2`._](https://scribd.sourcegraphcloud.com/users/kristianmills/batch-changes/sourcegraph-node-16-v2)