### PR TITLE
DATAPLAT-278: add permissions to create database for glue-create lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -724,6 +724,7 @@ data "aws_iam_policy_document" "glue_create" {
     actions = [
       "glue:GetDatabase",
       "glue:GetDatabases",
+      "glue:CreateDatabase"
     ]
     resources = [
       "*"


### PR DESCRIPTION
## Description
glue-create need extra permissions because it will create databases automatically 

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Testing considerations

<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Fix bug with logging` -->
- [ ] Commits are squashed in a logical and understandable history <!-- e.g. avoid 'fix' commits -->
- [ ] Thoroughly tested the changes in development and/or staging
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [!XYZ](https://github.com/scribd/REPO/pull/XYZ)
* [JIRXXX](https://scribdjira.atlassian.net/browse/JIRXXX)
* [Design Document](https://scribdjira.atlassian.net/wiki/spaces/SPACEID/pages/PAGEID)
* [Slack discussion](https://scribd.slack.com/archives/C0DSL144T/p1564610596278400)
