### PR TITLE
DATAPLAT-278: Add  glue:UpdateTable permissions to avoid error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -710,7 +710,8 @@ data "aws_iam_policy_document" "glue_create" {
       "glue:GetTable",
       "glue:GetTables",
       "glue:GetPartitions",
-      "glue:CreateTable"
+      "glue:CreateTable",
+      "glue:UpdateTable"
     ]
     resources = [
       "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog",


### PR DESCRIPTION
## Description
Without new permissions the glue-create lambda raises error:
![image](https://github.com/scribd/terraform-oxbow/assets/22071320/a592e78b-5d95-4696-a466-f1f2ee2e39f7)


<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Testing considerations

<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Fix bug with logging` -->
- [ ] Commits are squashed in a logical and understandable history <!-- e.g. avoid 'fix' commits -->
- [ ] Thoroughly tested the changes in development and/or staging
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [!XYZ](https://github.com/scribd/REPO/pull/XYZ)
* [JIRXXX](https://scribdjira.atlassian.net/browse/JIRXXX)
* [Design Document](https://scribdjira.atlassian.net/wiki/spaces/SPACEID/pages/PAGEID)
* [Slack discussion](https://scribd.slack.com/archives/C0DSL144T/p1564610596278400)
