### PR TITLE
Fixing Error in Terraform-data-warehouse prod deploy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -773,6 +773,8 @@ resource "aws_iam_policy" "glue_create_managed" {
 }
 
 resource "aws_iam_role" "glue_create" {
+  count = local.enable_glue_create ? 1 : 0
+
   name                = var.glue_create_config.iam_role_name
   assume_role_policy  = data.aws_iam_policy_document.glue_create_assume[0].json
   managed_policy_arns = [aws_iam_policy.glue_create_managed[0].arn]


### PR DESCRIPTION
## Description

This fixes the error encountered during Prod deployment of `terraform-data-warehouse`. Resource was getting created without the accompanied data iam policies (due to missing count flag)

```
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/aurora-snapshot-export_oxbow/main.tf line 777, in resource "aws_iam_role" "glue_create":
│  777:   assume_role_policy  = data.aws_iam_policy_document.glue_create_assume[0].json
│     ├────────────────
│     │ data.aws_iam_policy_document.glue_create_assume is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
╵
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/aurora-snapshot-export_oxbow/main.tf line 778, in resource "aws_iam_role" "glue_create":
│  778:   managed_policy_arns = [aws_iam_policy.glue_create_managed[0].arn]
│     ├────────────────
│     │ aws_iam_policy.glue_create_managed is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```

## Testing considerations

<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [X] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Fix bug with logging` -->
- [X] Commits are squashed in a logical and understandable history <!-- e.g. avoid 'fix' commits -->
- [X] Thoroughly tested the changes in development and/or staging
- [X] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [Prod Merge that Failed](https://github.com/scribd/terraform-data-warehouse/pull/1013)